### PR TITLE
Post boot

### DIFF
--- a/Files/bin/post_boot.sh
+++ b/Files/bin/post_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Version: 1.1.2  2022-05-20
+#  Version: 1.2.0  2022-05-23
 #
 #  Intended usage is for small systems where a cron might not be running and or
 #  needing to do some sanity checks after booting.
@@ -15,45 +15,62 @@
 #    * there are some first-run tasks that need to be done
 #    * services sometimes fail to start by init, restarting them tends to help
 
+respawn_log=/tmp//post_boot.log
+
+
+
+respawn_it() {
+    $0 will_run > $respawn_log 2>&1
+    exit 0
+}
+
+
 
 #
-#  If run with no params, spawn another instance in the background and exit
-#  in order to be inittab friendly
+#  If run with no params, respawn with output going to $respawn_log
+#  all to be inittab friendly
 #
 if [ "$1" = "" ]; then
-    $0 will_run >> /tmp/post_boot.log 2>> /tmp/post_boot.err &
-    exit 0
+    echo "with no param this is respawned, logging to: $respawn_log:"
+    respawn_it
 fi
 
-#
-# Give the system time to complete it's startup
-#
-sleep 10
-
 
 #
-#  Do all sanity checks needed...
+#  /dev/null gets screwed up at times.
+#  Recreate if it needs fixing.
 #
+if [ -z "$(ls -l /dev/null | grep 'root root 1, 3')" ]; then
+    rm /dev/null > /tmp/profile.debug 2>&1
+    mknod /dev/null c 1 3 >> /tmp/profile.debug 2>&1
+    chmod 666 /dev/null >> /tmp/profile.debug 2>&1
+
+    #
+    #  Since /dev/null was recreated respawn this (again),
+    #  in order for the redirects used on this script to work
+    #
+    respawn_it
+fi
+
 
 # The following is needed for upstream PR #1716
 if [ ! -e /dev/fd ]; then
-   ln -s /proc/self/fd /dev/fd
+    ln -s /proc/self/fd /dev/fd
 fi
 
 
 if [[ -e /etc/FIRSTBOOT ]]; then
-   # /dev/null gets screwed up at times.  Recreate just in case
-   # the first time we boot
-   rm /dev/null > /tmp/profile.debug 2>&1
-   mknod /dev/null c 1 3 >> /tmp/profile.debug 2>&1
-   chmod 666 /dev/null >> /tmp/profile.debug 2>&1
 
-   # Start a couple of services
-   rc-update add dcron
-   rc-update add runbg
+    # Start a couple of services
+    rc-update add dcron
+    rc-service dcron restart
+    rc-update add runbg
+    #rc-service runbg restart
 
-   rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
+    echo "FIRSTBOOT tasks done"
+    rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
 fi
+
 
 # Hack for Alpine 3.14.0
 OS=`/bin/cat /etc/alpine-release`
@@ -64,16 +81,15 @@ if [ $OS = '3.14.0' ]; then
     /usr/local/bin/fix_services
 fi
 
+
 # /etc/init.d/networking keeps getting an extra } written at the end
 # For some unknown reason.  Overwrite it when we login to hopefully
 # mitigate that
 #cp /root/init.d/networking /etc/init.d
 
 
-
-
 #
 #  Restart all services not in started state, should not be needed normally
 #  but here we are, and if they are already running, nothing will happen.
 #
-rc-status |grep -v -e started -e Runlevel:  | awk '{ print $1 }' | xargs -I % /etc/init.d/% restart
+rc-status  |grep -v -e started -e Runlevel:  | awk '{cmd="rc-service " $1 " restart" ; system(cmd)}'

--- a/Files/bin/post_boot.sh
+++ b/Files/bin/post_boot.sh
@@ -65,7 +65,7 @@ if [[ -e /etc/FIRSTBOOT ]]; then
     rc-update add dcron
     rc-service dcron restart
     rc-update add runbg
-    #rc-service runbg restart
+    rc-service runbg restart
 
     echo "FIRSTBOOT tasks done"
     rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now

--- a/Files/inittab
+++ b/Files/inittab
@@ -3,7 +3,7 @@
 ::sysinit:/sbin/openrc default
 ::sysinit:/sbin/openrc default
 ::wait:/sbin/openrc default
-::wait:/usr/local/bin/post_boot.sh default
+::once:/usr/local/bin/post_boot.sh
 
 # Set up a couple of getty's
 #tty1::respawn:/sbin/getty 38400 tty1

--- a/chroot_build_image
+++ b/chroot_build_image
@@ -4,7 +4,7 @@
 # Check to be sure we are not running this in /tmp/AOK
 
 # Read in vars
-. AOK_VARS
+. ./AOK_VARS
 
 SHORT_ALPINE=`echo $ALPINE_VERSION | cut -d"." -f 1,2`   # Neded for the wget below
 
@@ -33,7 +33,22 @@ if [ ! -f /tmp/AOK/build/BUILD_DONE ]; then  # Skip if we crashed during tar/com
    # Build in /tmp
    echo "Create /tmp/AOK/build, copy stuff"
    mkdir -p /tmp/AOK/build
-   busybox tar cf - --exclude='.git' --exclude='./main' --exclude='./save' . | (cd /tmp/AOK/build;tar xf -)
+
+
+   #
+   #  Despite having installed busybox, the original command just wouldnt run.
+   #  Skipping the busybox prefix solved that on the Debian family, like Ubuntu
+   #
+   #  TODO: Normally I would have put the common part of the command in
+   #  a variable to make sure they are in sync, but I just couldnt get that
+   #  to work, some escapes needed?  Should be fixed
+   #
+   if [ -f "/etc/debian_version" ]; then
+       tar cf - --exclude='.git' --exclude='./main' --exclude='./save' . | (cd /tmp/AOK/build;tar xf -)
+   else
+       busybox tar cf - --exclude='.git' --exclude='./main' --exclude='./save' . | (cd /tmp/AOK/build;tar xf -)
+   fi
+
 
    cd /tmp/AOK/build
 


### PR DESCRIPTION
I forgot to remove a debug statement, so new PR :)

* chroot_build_image Now works on Ubuntu
* updated inittab to match post_boots new behaviour
* Reworked post_boot
  - Turns out the services created in FIRST_BOOT were not properly started - fixed
  - Got rid of the sleep time
  - If /dev/null is recreated an additional respawn is needed in order for the redirects to work
   