### PR TITLE
More shell fixes

### DIFF
--- a/Files/bin/do_fix_services
+++ b/Files/bin/do_fix_services
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+#  do_XX scripts does the actual thing for XX
+#
+#  This way XX can be human friendly andd give help
+#  whilst do_XX just does it, so more suitable to be called
+#  from oher scripts
+# 
+
+rc-status  |grep -v -e started -e Runlevel:  | awk '{cmd="rc-service " $1 " restart" ; system(cmd)}'

--- a/Files/bin/fix_services
+++ b/Files/bin/fix_services
@@ -1,14 +1,25 @@
-#!/usr/bin/perl
-# Quick hack to deal with services not starting properly with Alpine 3.14
+#!/bin/sh
+#
+#  Restart all non-running services
+#
+version="0.1.0  2022-05-25"
 
-@services = `rc-status | grep '^ '`;
+prog_name=$(basename "$0")
 
-while($check = shift(@services)) {
-   chop $check;
-   ($name, $trash, $state) = split(/\s{2,}/, $check);
-   if($state =~ /crashed/) {
-      `rc-service$name restart >/dev/null 2>/dev/null`; # If it is crashed, restart
-   } elsif($state =~ /stopped/) {
-      `rc-service$name start >/dev/null 2>/dev/null`; # If it is stopped, start
-   }
-}
+# execute again as root
+if [ "$(whoami)" != "root" ]; then
+    echo "Executing as root"
+    # using $0 instead of full path makes location not hardcoded
+    sudo "$0"
+    exit 0
+fi
+
+
+
+echo "$prog_name  $version"
+echo
+echo "This restarts all services not in a running state"
+echo
+
+CURRENT_DIR=$( cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P )
+"$CURRENT_DIR"/do_fix_services

--- a/Files/bin/iCloud
+++ b/Files/bin/iCloud
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Make it easier for people to mount their iCloud drive in iSh, 
 # Also create a /iCloud/AOK directory
 

--- a/Files/bin/installed
+++ b/Files/bin/installed
@@ -1,3 +1,3 @@
-#!/bin/ash
+#!/bin/sh
 
 apk -vv info | sort

--- a/Files/bin/ipad_tmux
+++ b/Files/bin/ipad_tmux
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh
 tmux new-session -s "My iPad" -d
 tmux split-window -h
 tmux -2 attach-session -d 

--- a/Files/bin/iphone_tmux
+++ b/Files/bin/iphone_tmux
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh
 tmux new-session -s "My iPhone" -d
 tmux split-window -v
 tmux -2 attach-session -d 

--- a/Files/bin/pbcopy
+++ b/Files/bin/pbcopy
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Simple script to put text into the cut and paste buffer.
 # Example:  dmesg | pbcopy
 # Based on a script posted by Ian Edington on the ish Discord server

--- a/Files/bin/showip
+++ b/Files/bin/showip
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "This only works properly with wireless connections for now"
 
-INT_IP=`curl ifconfig.me 2>/dev/null`
+INT_IP="$(curl ifconfig.me 2>/dev/null)"
 
 echo "Internet IP: $INT_IP"
 
-LOCAL_IP=`/usr/local/bin/idev_ip | cut -d: -f 2`
+LOCAL_IP="$(/usr/local/bin/idev_ip | cut -d: -f 2)"
 
 echo "Local IP:$LOCAL_IP"

--- a/Files/bin/update
+++ b/Files/bin/update
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+# execute again as root
+if [ "$(whoami)" != "root" ]; then
+    echo "Executing as root"
+    # using $0 instead of full path makes location not hardcoded
+    sudo "$0" "$@"
+    exit 0
+fi
+
+
 echo "Making sure we have the latest Alpine repository updates"
 apk update
 echo

--- a/Files/bin/update
+++ b/Files/bin/update
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 echo "Making sure we have the latest Alpine repository updates"
 apk update
 echo

--- a/Files/bin/version
+++ b/Files/bin/version
@@ -1,2 +1,2 @@
-#!/bin/ash
+#!/bin/sh
 cat /proc/ish/version

--- a/Files/bin/what_owns
+++ b/Files/bin/what_owns
@@ -1,3 +1,3 @@
-#!/bin/ash
+#!/bin/sh
 
-apk info --who-owns $1
+apk info --who-owns "$1"


### PR DESCRIPTION
Since the actual action taken in fix_services is also done in post_boot, I broke the action to a separate do_fix_services script, this is called from both to reduce code duplication.
do_fix_services has documentation about the purpose of do_XX scripts

* post_boot.sh
  - shellcheck
  - uses do_fix_services
* do_fix_services
  - new script. Does the service restart
* fix_services
  - rewrite as POSIX script
  - uses do_fix_services
* what_owns - shellcheck
* version - shellcheck
* update 
  - shellcheck
  - added run as root feature  
* show_ip
  - shellcheck
  - Since I dont have local DNS, I can't test to ensure it works as intended, I leave that to you
 * pbcopy - shellcheck
 * installed - shellcheck
 * ipad_tmux  - shellcheck
 * iphone_tmux - shellcheck