### PR TITLE
Shell changes

### DIFF
--- a/Files/bin/fix_services
+++ b/Files/bin/fix_services
@@ -21,5 +21,6 @@ echo
 echo "This restarts all services not in a running state"
 echo
 
-CURRENT_DIR=$( cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P )
-"$CURRENT_DIR"/do_fix_services
+# shellcheck disable=SC1007
+current_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+"$current_dir"/do_fix_services

--- a/Files/bin/pkg_groups
+++ b/Files/bin/pkg_groups
@@ -19,7 +19,7 @@
 #  In the end its MIT so feel free to change it anyway you want,
 #  this is only to ease maintenance.
 #
-version="0.4.0a3  2022-05-24"
+version="0.4.1  2022-05-25"
 
 
 #
@@ -78,7 +78,7 @@ check_for_option() {
 	    else
 		a_param="[-a] & "
 	    fi
-            echo "usage: $prog_name $a_param[-h] | [-g] | [-l] | group1 group2 -group3 ..."
+            echo "usage: $prog_name ${a_param}[-h] | [-g] | [-l] | group1 group2 -group3 ..."
             echo
             echo "This is a tool to install/uninstall groups of packages"
             echo "prefixing a group name with - means uninstall that group"

--- a/Files/bin/post_boot.sh
+++ b/Files/bin/post_boot.sh
@@ -101,5 +101,6 @@ fi
 #  Restart all services not in started state, should not be needed normally
 #  but here we are, and if they are already running, nothing will happen.
 #
-current_dir=$( cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P )
+# shellcheck disable=SC1007
+current_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 "$current_dir"/do_fix_services

--- a/Files/bin/vnc_start
+++ b/Files/bin/vnc_start
@@ -1,11 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Stupidly simple script to start vnc.  
 
 # Remove stale locks from /tmp
 
-CHECK=`ps -o args | grep "{startx} /bin/sh /usr/bin/startx" | wc -l`
-
+CHECK="$(pgrep -c -f "/bin/sh /usr/bin/startx")"
 
 # Do minimal sanity check to see if vnc/X11 are installed
 if [ ! -f /etc/X11/xorg.conf.d/10-headless.conf ]; then
@@ -14,10 +13,10 @@ if [ ! -f /etc/X11/xorg.conf.d/10-headless.conf ]; then
 fi
 
 # Only run once.  The grep causes CHECK to equal 1
-if [ $CHECK -eq 1 ]; then # Nothing running, clear stale locks
+if [ "$CHECK" -eq 0 ]; then # Nothing running, clear stale locks
    rm -rf /tmp/.X* 
 else
-   echo "$0 is already running.  We're done here."
+   echo "startx is already running.  We're done here."
    exit 1
 fi
 


### PR DESCRIPTION
This is fully tested, and can be applied independently of the vnc PR

* post_boot.sh
  - changed detection of current dir
  - The new syntax passes both shellcheck and checkbashisms
* pkg_groups
  - variable separation. The syntax "$a_param[-h] " works as intended, but gives a shellcheck warning
    "Use braces when expanding array". So it makes sense to clean it up into
    "${a_param}[-h]"
* fix_services
  - now passes checkbashisms
  - also lowercased current_dir
  