### PR TITLE
Shell changes 2

### DIFF
--- a/Files/bin/fix_services
+++ b/Files/bin/fix_services
@@ -21,5 +21,6 @@ echo
 echo "This restarts all services not in a running state"
 echo
 
-CURRENT_DIR=$( cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P )
-"$CURRENT_DIR"/do_fix_services
+# shellcheck disable=SC1007
+current_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+"$current_dir"/do_fix_services

--- a/Files/bin/pkg_groups
+++ b/Files/bin/pkg_groups
@@ -19,7 +19,7 @@
 #  In the end its MIT so feel free to change it anyway you want,
 #  this is only to ease maintenance.
 #
-version="0.4.0a3  2022-05-24"
+version="0.4.1  2022-05-25"
 
 
 #
@@ -78,7 +78,7 @@ check_for_option() {
 	    else
 		a_param="[-a] & "
 	    fi
-            echo "usage: $prog_name $a_param[-h] | [-g] | [-l] | group1 group2 -group3 ..."
+            echo "usage: $prog_name ${a_param}[-h] | [-g] | [-l] | group1 group2 -group3 ..."
             echo
             echo "This is a tool to install/uninstall groups of packages"
             echo "prefixing a group name with - means uninstall that group"

--- a/Files/bin/post_boot.sh
+++ b/Files/bin/post_boot.sh
@@ -101,5 +101,6 @@ fi
 #  Restart all services not in started state, should not be needed normally
 #  but here we are, and if they are already running, nothing will happen.
 #
-current_dir=$( cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P )
+# shellcheck disable=SC1007
+current_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 "$current_dir"/do_fix_services


### PR DESCRIPTION
This is fully tested, and can be applied independently of the vnc PR

* post_boot.sh
  - changed detection of current dir
  - The new syntax passes both shellcheck and checkbashisms
* pkg_groups
  - variable separation. The syntax "$a_param[-h] " works as intended, but gives a shellcheck warning
    "Use braces when expanding array". So it makes sense to clean it up into
    "${a_param}[-h]"
* fix_services
  - now passes checkbashisms
  - also lowercased current_dir
  