### PR TITLE
get_apk uses SHORT_ALPINE

### DIFF
--- a/Files/bin/get_apk
+++ b/Files/bin/get_apk
@@ -8,8 +8,7 @@ if [ -z "$SHORT_ALPINE" ]; then
 fi
 
 # Just a sanity reference can be deleted to reduce clutter
-echo " SHORT_ALPINE is: [$SHORT_ALPINE]"
-
+echo "=====   using release: [$SHORT_ALPINE]   ====="
 
 apk_name="$(wget -O - http://dl-cdn.alpinelinux.org/alpine/v${SHORT_ALPINE}/main/x86 | grep apk-tools-static | cut -d\" -f 2)"
 
@@ -19,8 +18,7 @@ if [ -z "$apk_name" ]; then
 fi
 
 # Just a sanity reference can be deleted to reduce clutter
-echo "apk-tools-static used: $apk_name"
-
+echo "=====   apk-tools-static used: $apk_name   ====="
 
 wget -c -qO- http://dl-cdn.alpinelinux.org/alpine/v${SHORT_ALPINE}/main/x86/$apk_name | tar -xz sbin/apk.static
 ./sbin/apk.static add apk-tools && rm -rf sbin/

--- a/Files/bin/get_apk
+++ b/Files/bin/get_apk
@@ -1,3 +1,26 @@
 #!/bin/sh
-wget -c -qO- http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86/apk-tools-static-2.10.5-r1.apk | tar -xz sbin/apk.static 
+
+SHORT_ALPINE="$1"
+
+if [ -z "$SHORT_ALPINE" ]; then
+    echo "ERROR: no SHORT_ALPINE defined"
+    exit 1
+fi
+
+# Just a sanity reference can be deleted to reduce clutter
+echo " SHORT_ALPINE is: [$SHORT_ALPINE]"
+
+
+apk_name="$(wget -O - http://dl-cdn.alpinelinux.org/alpine/v${SHORT_ALPINE}/main/x86 | grep apk-tools-static | cut -d\" -f 2)"
+
+if [ -z "$apk_name" ]; then
+    echo "ERROR: no apk-tools-static found"
+    exit 1
+fi
+
+# Just a sanity reference can be deleted to reduce clutter
+echo "apk-tools-static used: $apk_name"
+
+
+wget -c -qO- http://dl-cdn.alpinelinux.org/alpine/v${SHORT_ALPINE}/main/x86/$apk_name | tar -xz sbin/apk.static
 ./sbin/apk.static add apk-tools && rm -rf sbin/

--- a/chroot_build_image
+++ b/chroot_build_image
@@ -10,8 +10,8 @@ SHORT_ALPINE=`echo $ALPINE_VERSION | cut -d"." -f 1,2`   # Neded for the wget be
 
 # Get apk if not installed
 if [ ! -f /sbin/apk ]; then
-    echo "Installing APK"
-    Files/bin/get_apk
+    echo "Installing APK $SHORT_ALPINE"
+    Files/bin/get_apk $SHORT_ALPINE || exit 1
 fi
 
 # Clean up previous run

--- a/chroot_build_image
+++ b/chroot_build_image
@@ -11,7 +11,7 @@ SHORT_ALPINE=`echo $ALPINE_VERSION | cut -d"." -f 1,2`   # Neded for the wget be
 # Get apk if not installed
 if [ ! -f /sbin/apk ]; then
     echo "Installing APK $SHORT_ALPINE"
-    Files/bin/get_apk $SHORT_ALPINE || exit 1
+    Files/bin/get_apk $SHORT_ALPINE
 fi
 
 # Clean up previous run


### PR DESCRIPTION
I have updated chroot_build_image to provide SHORT_ALPINE
and get_apk to use it.
get_apk inspects the repository and retrieves the found apk-tools-static

I have tested this on Ubuntu, with the default version, and it generates a good FS

With 3.14.6 I get something that runs, a quick test only displayed htop to fail, but that is far from a full test

I could also build 3.16.0, but it gets stuck on the login prompt endlessly repeating with an error.