### PR TITLE
Update AOK_VARS

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -8,7 +8,7 @@ AOK_VERSION_SHORT="A-96_3.15"
 
 # APK's that get installed on image build and impact image size
 #CORE_APKS='openssh openrc zsh bash tmux git curl openssl-dev shadow sudo busybox-extras mosh fortune elinks dcron dcron-openrc vim nano ssl_client ncftp coreutils findutils tar ncurses-dev ncurses file less sed gawk grep util-linux tzdata'
-CORE_APKS='openssh openrc zsh bash tmux git curl openssl-dev shadow sudo busybox-extras mosh fortune elinks dcron dcron-openrc vim nano ssl_client ncftp coreutils findutils tar ncurses-dev ncurses file less sed gawk grep util-linux tzdata htop procps strace rsync rsync-doc'
+CORE_APKS='openssh openrc zsh bash tmux git curl openssl-dev shadow sudo busybox-extras mosh fortune elinks dcron dcron-openrc vim nano ssl_client ncftp coreutils findutils tar ncurses-dev ncurses file less sed gawk grep util-linux tzdata htop procps strace rsync'
 
 VNC_APKS='x11vnc x11vnc-doc xvfb xterm xorg-server xf86-video-dummy i3wm i3status i3lock xdpyinfo xdpyinfo-doc i3wm-doc i3lock-doc i3status-doc ttf-dejavu'
 


### PR DESCRIPTION
Remove 'rsync-docs' from core.  It's in BLOATDOCS_APKS, which is where it belongs.